### PR TITLE
Fixed integer initialization issue in rwf

### DIFF
--- a/fortran/rwfortran.f
+++ b/fortran/rwfortran.f
@@ -14,19 +14,19 @@ Cf2py integer intent(hide),depend(list) :: n=shape(list,0)
 c
 c
 c
-      subroutine wlist_int(string,list,n)
-      integer  :: n,i
-      real*8   :: list(n)
-      character*11 :: tmp
-      character*(*) :: string
-Cf2py intent(inout) string
-Cf2py intent(in,copy) list
-Cf2py integer intent(hide),depend(list) :: n=shape(list,0)
-      do i = 1,n
-         call wint(list(i),tmp)
-         string((i-1)*11+1:i*11) = tmp
-      enddo
-      end subroutine wlist_int
+c       subroutine wlist_int(string,list,n)
+c       integer   :: n,i
+c       integer*8 :: list(n)
+c       character*11 :: tmp
+c       character*(*) :: string
+c Cf2py intent(inout) string
+c Cf2py intent(in,copy) list
+c Cf2py integer intent(hide),depend(list) :: n=shape(list,0)
+c       do i = 1,n
+c          call wint(list(i),tmp)
+c          string((i-1)*11+1:i*11) = tmp
+c       enddo
+c       end subroutine wlist_int
 c
 c
 c
@@ -66,13 +66,13 @@ Cf2py intent(in) x
 c
 c
 c
-      subroutine wint(x,a)
-      real*8   :: x
-      integer*4 :: y
-      character*11 :: a
-      y = int(x)
-      write(a,'(I11)') y
-      end subroutine wint
+c       subroutine wint(x,a)
+c       real*8   :: x
+c       integer :: y
+c       character*11 :: a
+c       y = int(x)
+c       write(a,'(I11)') y
+c       end subroutine wint
 c
 c
 c
@@ -153,7 +153,7 @@ c
 c
       subroutine rilist(string,io_status,ilist,n)
       integer  :: n,i,io_status
-      integer*8 :: ilist(n)
+      integer*4 :: ilist(n)
       character*80 :: string
 Cf2py intent(inout) string
 Cf2py intent(inout) io_status


### PR DESCRIPTION
It turns out that one of the integer variables (line 156) actually needs to be initialized as length 4.  Length 8 causes the same errors we had seen with some of the other variables where it had expected length 8 but received 4 except in reverse.

Resolves Issue #30 

(I'm not really sure what's going on with the differences with lines 17-29 and 69-75 being uncommented in what GitHub is saying is your current version of the file in the develop branch.  I pulled the file directly from your develop branch before editing it and can confirm both sets of lines are also commented in that file.)