### PR TITLE
Multi-group grids available in ERRORR can be selected

### DIFF
--- a/sandy/core/endf6.py
+++ b/sandy/core/endf6.py
@@ -1408,7 +1408,8 @@ If you want to process 0K cross sections use `temperature=0.1`.
                    .add_sections(section_3_pendf) \
                    .add_sections(section_1451_pendf)
 
-    def get_errorr(self, njoy, pendf=None):
+    def get_errorr(self, njoy, pendf=None, temperatures=0, suffixes=0,
+                   group_structure=None):
         """
         .. important:: this module uses `read_formatted_file`, which is no
                        longer supported.
@@ -1444,6 +1445,13 @@ If you want to process 0K cross sections use `temperature=0.1`.
                 pendf.to_file(pendftape)
             else:
                 pendftape = None
+
+            if not isinstance(temperatures, list):
+                temperatures = [temperatures]
+            if not isinstance(suffixes, list):
+                suffixes = [suffixes]
+
+            ign = 1 if group_structure else 2
             outputs = sandy.njoy.process(
                     endf6file,
                     pendftape=pendftape,
@@ -1458,9 +1466,11 @@ If you want to process 0K cross sections use `temperature=0.1`.
                     wdir=".",
                     keep_pendf=False,
                     exe=njoy,
-                    temperatures=[0],
-                    suffixes=[0],
-                    err=0.005
+                    temperatures=temperatures,
+                    suffixes=suffixes,
+                    err=0.005,
+                    ek=group_structure,
+                    ign=ign,
                     )[2]  # keep only pendf filename
             errorr = sandy.read_formatted_file(outputs["tape33"])
         return errorr

--- a/sandy/njoy.py
+++ b/sandy/njoy.py
@@ -592,9 +592,9 @@ def _acer_input(endfin, pendfin, aceout, dirout, mat,
 
 
 def _errorr_input(endfin, pendfin, errorrout, mat,
-                  ign=2,
+                  ign=2, ek=None,
                   iwt=2,
-                  temp=NJOY_TEMPERATURES[0],
+                  temp=None,
                   iprint=False,
                   **kwargs):
     """
@@ -612,6 +612,8 @@ def _errorr_input(endfin, pendfin, errorrout, mat,
         MAT number
     ign : `int`
         neutron group option (default is 2, csewg 239-group structure)
+    ek : `list`
+        derived cross section energy bounds (default is `None`)
     iwt : `int`
         weight function option (default is 2, constant)
     temp : `float`
@@ -627,9 +629,25 @@ def _errorr_input(endfin, pendfin, errorrout, mat,
     text = ["errorr"]
     text += [f"{endfin:d} {pendfin:d} 0 {errorrout:d} 0 /"]
     printflag = int(iprint)
-    text += [f"{mat:d} {ign:d} {iwt:d} {printflag:d} 1 /"]
-    text += [f"{printflag:d} {temp:.1f} /"]
-    text += ["0 33 /"]
+    if temp is None:
+        temp = NJOY_TEMPERATURES[0]
+
+    if ign == 1:
+        if not isinstance(ek, list):
+            msg = "ek should be of type list instead of {} with ign=1!".format(type(ek))
+            raise SandyError(msg)
+        else:
+            nk = len(ek)-1
+        text += [f"{mat:d} {ign:d} {iwt:d} {printflag:d} 1 /"]
+        text += [f"{printflag:d} {temp:.1f} /"]
+        text += ["0 33 /"]
+        text += [f"{nk} /"]
+        text += ["{} /".format(" ".join(str(e) for e in ek))]
+
+    else:
+        text += [f"{mat:d} {ign:d} {iwt:d} {printflag:d} 1 /"]
+        text += [f"{printflag:d} {temp:.1f} /"]
+        text += ["0 33 /"]
     return "\n".join(text) + "\n"
 
 


### PR DESCRIPTION
Scope
=====
* Let the user select the multi-group grid among the ones available in the ERRORR module of NJOY (including arbitrary defined grids) when the covariance matrix is generated 
* Let the user specify the temperatures and the suffix for the .errorr file
Example
=======
Please find attached a file that can be used for testing my modifications. In this case I want to generate some covariance matrices with the ECCO-33 grid
```
"""
Author: N. Abrate.

File: GetCovariance.py

Description: Class to employ SANDY and NJOY codes to produce and extract
             multi-group covariance matrices
"""
import os
import shutil as sh
from pathlib import Path
import numpy as np
import pandas as pd
import sandy
from sandy.formats.utils import XsCov, EnergyCov

cwd = Path.cwd()

mynuclides = {20040   : "He-004", 30070   : "Li-007", 50100   : "B-010",
              50110   : "B-011", 60120    : "C-012", 90190    : "F-019",
              130270  : "Al-027", 140280  : "Si-028", 220480  : "Ti-048",
              230510  : "V-051", 240520   : "Cr-052", 250550  : "Mn-055",
              260560  : "Fe-056", 260580  : "Fe-058", 270590  : "Co-059",
              280580  : "Ni-058", 290630  : "Cu-063", 420960  : "Mo-096",
              741840  : "W-184", 902320   : "Th-232", 922330  : "U-233",}

class GetCovariance():
    def __init__(self, za, temperature, group_structure):
        cwd = Path.cwd()
        G = len(group_structure)-1
        mysuff = int(temperature/100)
        errorr_name = '{}.{:02d}c.errorr'.format(str(za)[:-1], mysuff)
        errorr_path = cwd.joinpath('errorr',  f'{G}G', errorr_name)
        if Path.exists(errorr_path):
            myerrorr = sandy.formats.Errorr.from_file(errorr_path)
        else:
            myerrorr = GetCovariance.run_errorr(za, temperature,
                                                group_structure)

        self.cov =  XsCov.from_errorr(myerrorr)

    def run_errorr(za, temperature, group_structure):
        G = len(group_structure)-1
        mysuff = int(temperature/100)
        cwd = Path.cwd()
        endf_name = '{}.endf'.format(mynuclides[za])
        pendf_name = '{}_{:02d}c.pendf'.format(mynuclides[za], mysuff)
        condition = not Path.exists(cwd.joinpath('pendf', pendf_name)) or not \
            Path.exists(cwd.joinpath('endf', endf_name))
        if condition:
            if not Path.exists(cwd.joinpath('endf')):
                os.mkdir(cwd.joinpath('endf'))
            if not Path.exists(cwd.joinpath('pendf')):
                os.mkdir(cwd.joinpath('pendf'))
            # get ENDF-6 files and companion PENDF
            endf = sandy.get_endf6_file("endfb_80", "xs", za)
            endf.to_file('{}.endf'.format(mynuclides[za]))
            pendf = endf.get_pendf(temperature=1023)
            pendf.to_file(pendf_name)
            sh.move(cwd.joinpath(endf_name), cwd.joinpath('endf', endf_name))
            sh.move(cwd.joinpath(pendf_name), cwd.joinpath('pendf', pendf_name))
        else:
            endf_path = str(cwd.joinpath('endf', endf_name))
            pendf_path = str(cwd.joinpath('pendf', pendf_name))
            endf = sandy.Endf6.from_file(endf_path)
            pendf = sandy.Endf6.from_file(pendf_path)
        # run ERRORR
        myerrorr = endf.get_errorr(os.environ['NJOY'], pendf=pendf,
                                   temperatures=temperature,
                                   suffixes='{:02d}c'.format(mysuff),
                                   group_structure=group_structure)
        if not Path.exists(cwd.joinpath('errorr')):
            os.mkdir(cwd.joinpath('errorr'))

        if not Path.exists(cwd.joinpath('errorr', f'{G}G')):
            os.mkdir(cwd.joinpath('errorr',  f'{G}G'))

        errorr_name = '{}.{:02d}c.errorr'.format(str(za)[:-1], mysuff)
        sh.move(cwd.joinpath(errorr_name), cwd.joinpath('errorr',  f'{G}G',
                                                      errorr_name))
        return myerrorr


if __name__ == "__main__":
    # --- input
    za = 90190
    ecco33 = [1.00001e-05, 1.00000e-01, 5.40000e-01, 4.00000e+00, 8.31529e+00,
              1.37096e+01, 2.26033e+01, 4.01690e+01, 6.79040e+01, 9.16609e+01,
              1.48625e+02, 3.04325e+02, 4.53999e+02, 7.48518e+02, 1.23410e+03,
              2.03468e+03, 3.35463e+03, 5.53084e+03, 9.11882e+03, 1.50344e+04,
              2.47875e+04, 4.08677e+04, 6.73795e+04, 1.11090e+05, 1.83156e+05,
              3.01974e+05, 4.97871e+05, 8.20850e+05, 1.35335e+06, 2.23130e+06,
              3.67879e+06, 6.06531e+06, 1.00000e+07, 1.96403e+07]
    os.environ['NJOY'] = '/usr/local/bin/njoy-2016.47'
    T = 1023
    mycov = GetCovariance(za, T, ecco33)
```