### PR TITLE
eig no sparse

### DIFF
--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -324,13 +324,14 @@ class CategoryCov():
                     0            1
         0 7.07107e-01 -7.07107e-01
         1 7.07107e-01  7.07107e-01
+        
+        >>> endf6 = sandy.get_endf6_file('jeff_33','xs', 922350)
+        >>> Cov = sandy.XsCov.from_endf6(endf6)
+        >>> Cov = sandy.CategoryCov(Cov)
+        >>> len(Cov.eig()[0])
+        295
         """
-        cov = self.to_sparse()
-        warnings.filterwarnings("ignore")
-        try:
-            E, V = spsl.eigs(cov)
-        except TypeError or ValueError:
-            E, V = scipy.linalg.eig(cov.toarray())
+        E, V = scipy.linalg.eig(self.data)
         E = pd.Series(E.real, name="eigenvalues")
         V = pd.DataFrame(V.real)
         if sort:

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -324,12 +324,24 @@ class CategoryCov():
                     0            1
         0 7.07107e-01 -7.07107e-01
         1 7.07107e-01  7.07107e-01
-        
-        >>> endf6 = sandy.get_endf6_file('jeff_33','xs', 922350)
-        >>> Cov = sandy.XsCov.from_endf6(endf6)
+
+        >>> Cov = sandy.random_cov(50,seed=11)
         >>> Cov = sandy.CategoryCov(Cov)
         >>> len(Cov.eig()[0])
-        295
+        50
+
+        >>> Cov = sandy.random_cov(3,seed=1)
+        >>> sandy.CategoryCov(Cov).eig()[0]
+        0    8.49942e-01
+        1    1.18850e-01
+        2   -3.32188e-02
+        Name: eigenvalues, dtype: float64
+
+        >>> endf6 = sandy.get_endf6_file("jeff_33", "xs", 10010)
+        >>> err = endf6.get_errorr(ek=sandy.energy_grids.CASMO12, err=1)
+        >>> Cov = err.get_cov()
+        >>> len(Cov.eig()[0]), Cov.data.shape
+        (39, (39, 39))
         """
         E, V = scipy.linalg.eig(self.data)
         E = pd.Series(E.real, name="eigenvalues")


### PR DESCRIPTION
There is no way with the `scipy.sparse.linalg.eigs()` to obtain all the eigenvalues. The parameter k must be smaller than N-1, with N the dimension of the square matrix. I removed the option of doing it with the sparse matrix and now it is done with `scipy.linalg.eig()`. I put another example with a real covariance matrix  