### PR TITLE
random correction

### DIFF
--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -307,6 +307,7 @@ class CategoryCov():
         tolerance : `float`, optional, default is `None`
             truncation proportional to the magnitude of the largest positive eigenvalue,
             e.g. 1000 to cut all the eigenvalues 1000 times lower than the largest eigenvalue
+            or np.inf to cut all the eigenvalues lower than zero
 
         Returns
         -------
@@ -330,6 +331,16 @@ class CategoryCov():
         
         >>> sandy.CategoryCov([[0.1, 0.1], [0.1, 1]]).eig(tolerance=10)[0]
         0   1.01098e+00
+        1   0.00000e+00
+        Name: eigenvalues, dtype: float64
+        
+        >>> sandy.CategoryCov([[1, 2], [2, 1]]).eig()[0]
+        0    3.00000e+00
+        1   -1.00000e+00
+        Name: eigenvalues, dtype: float64
+        
+        >>> sandy.CategoryCov([[1, 2], [2, 1]]).eig(tolerance=np.inf)[0]
+        0   3.00000e+00
         1   0.00000e+00
         Name: eigenvalues, dtype: float64
 

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -151,7 +151,7 @@ class _Cov(np.ndarray):
         nonzero_idxs = np.flatnonzero(np.diag(self))
         cov_reduced = self[nonzero_idxs][:, nonzero_idxs]
         return nonzero_idxs, cov_reduced
-
+        
     @classmethod
     def _restore_size(cls, nonzero_idxs, cov_reduced, dim):
         """
@@ -397,15 +397,9 @@ class CategoryCov():
                             columns=self.data.columns,
                             )
 
-    def _reduce_size(self, tolerance=1e-20):
+    def _reduce_size(self):
         """
         Reduces the size of the matrix, erasing the zero values.
-
-        Parameters
-        ----------
-        tolerance : `float`
-            threshold beyond which the eigenvalues are considered to be zero,
-            default is 1e-20
 
         Returns
         -------
@@ -433,12 +427,11 @@ class CategoryCov():
         >>> equal_arrays = comparison.all()
         >>> assert equal_arrays == True
         >>> reduce_matrix
-                      1	          2
-        1	2.00000e+00	0.00000e+00
-        2	0.00000e+00	3.00000e+00
+                    1           2
+        1 2.00000e+00 0.00000e+00
+        2 0.00000e+00 3.00000e+00
         """
-        E = self.eig(sort=False)[0]
-        nonzero_idxs = np.where(abs(E) >= tolerance)[0]
+        nonzero_idxs = np.flatnonzero(np.diag(self.data))
         cov_reduced = self.data.iloc[nonzero_idxs, nonzero_idxs]
         return nonzero_idxs, cov_reduced
 
@@ -479,9 +472,9 @@ class CategoryCov():
         >>> M_nonzero_idxs, M_reduce = S._reduce_size()
         >>> M_reduce[::] = 1
         >>> M_reduce
-                      1	          2
-        1	1.00000e+00	1.00000e+00
-        2	1.00000e+00	1.00000e+00
+                    1           2
+        1 1.00000e+00 1.00000e+00
+        2 1.00000e+00 1.00000e+00
 
         >>> sandy.CategoryCov._restore_size(M_nonzero_idxs, M_reduce.values, len(S.data))
                     0           1           2           3

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -325,8 +325,7 @@ class CategoryCov():
         0 7.07107e-01 -7.07107e-01
         1 7.07107e-01  7.07107e-01
 
-        >>> Cov = sandy.random_cov(50,seed=11)
-        >>> Cov = sandy.CategoryCov(Cov)
+        >>> Cov = sandy.CategoryCov.random_cov(50,seed=11)
         >>> assert len(Cov.eig()[0]) == Cov.data.shape[0]
 
         >>> Cov = sandy.random_cov(3,seed=1)
@@ -339,7 +338,8 @@ class CategoryCov():
         >>> endf6 = sandy.get_endf6_file("jeff_33", "xs", 10010)
         >>> err = endf6.get_errorr(ek=sandy.energy_grids.CASMO12, err=1)
         >>> Cov = err.get_cov()
-        >>> assert len(Cov.eig()[0]) == Cov.data.shape[0]
+        >>> len(Cov.eig()[0]), Cov.data.shape
+        (39, (39, 39))
         """
         E, V = scipy.linalg.eig(self.data)
         E = pd.Series(E.real, name="eigenvalues")

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -408,7 +408,7 @@ class CategoryCov():
         >>> ek = sandy.energy_grids.CASMO12
         >>> err = endf6.get_errorr(ek=ek, err=1)
         >>> cov = err.get_cov()
-        >>> cov.eig()[0].sort_values(ascending=False).head(10)
+        >>> cov.eig()[0].sort_values(ascending=False).head(7)
         0    3.66411e-01
         1    7.05311e-03
         2    1.55346e-03
@@ -416,9 +416,6 @@ class CategoryCov():
         4    1.81374e-05
         5    1.81078e-06
         6    1.26691e-07
-        7    6.03618e-10
-        8    4.74727e-11
-        11   6.46354e-12
         Name: eigenvalues, dtype: float64
         
         >>> assert not (cov.eig()[0] >= 0).all()

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -325,7 +325,8 @@ class CategoryCov():
         0 7.07107e-01 -7.07107e-01
         1 7.07107e-01  7.07107e-01
 
-        >>> Cov = sandy.CategoryCov.random_cov(50,seed=11)
+        >>> Cov = sandy.random_cov(50,seed=11)
+        >>> Cov = sandy.CategoryCov(Cov)
         >>> assert len(Cov.eig()[0]) == Cov.data.shape[0]
 
         >>> Cov = sandy.random_cov(3,seed=1)
@@ -338,8 +339,7 @@ class CategoryCov():
         >>> endf6 = sandy.get_endf6_file("jeff_33", "xs", 10010)
         >>> err = endf6.get_errorr(ek=sandy.energy_grids.CASMO12, err=1)
         >>> Cov = err.get_cov()
-        >>> len(Cov.eig()[0]), Cov.data.shape
-        (39, (39, 39))
+        >>> assert len(Cov.eig()[0]) == Cov.data.shape[0]
         """
         E, V = scipy.linalg.eig(self.data)
         E = pd.Series(E.real, name="eigenvalues")
@@ -397,15 +397,15 @@ class CategoryCov():
                             columns=self.data.columns,
                             )
 
-    def _reduce_size(self, toll=1e-14):
+    def _reduce_size(self, tolerance=1e-20):
         """
         Reduces the size of the matrix, erasing the zero values.
 
         Parameters
         ----------
-        toll : `float`
+        tolerance : `float`
             threshold beyond which the eigenvalues are considered to be zero,
-            default is 1e-14
+            default is 1e-20
 
         Returns
         -------
@@ -438,8 +438,8 @@ class CategoryCov():
         2	0.00000e+00	3.00000e+00
         """
         E = self.eig(sort=False)[0]
-        nonzero_idxs = np.where(abs(E) > toll)[0]
-        cov_reduced = self.data.loc[nonzero_idxs, nonzero_idxs]
+        nonzero_idxs = np.where(abs(E) >= tolerance)[0]
+        cov_reduced = self.data.iloc[nonzero_idxs, nonzero_idxs]
         return nonzero_idxs, cov_reduced
 
     @classmethod

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -232,14 +232,19 @@ class _Cov(np.ndarray):
 class CategoryCov():
     """
 
-    Attributes
+    Properties
     ----------
     data
         covariance matrix as a dataframe
+    size
+        first dimension of the ocvariance matrix
     std
-        series of standard deviations
-    corr
-        correlation matrix
+        `pd.Series` of standard deviations
+
+    Methods
+    -------
+    get_corr
+        extract correlation matrix from covariance matrix
     """
 
     def __repr__(self):
@@ -296,86 +301,6 @@ class CategoryCov():
     def size(self):
         return self.data.values.shape[0]
 
-    def eig(self, sort=True, tolerance=None):
-        """
-        Extract eigenvalues and eigenvectors.
-
-        Parameters
-        ----------
-        sort : `bool`, optional, default is `True`
-            flag to return sorted eigenvalues and eigenfunctions
-        tolerance : `float`, optional, default is `None`
-            truncation proportional to the magnitude of the largest positive eigenvalue,
-            e.g. 1000 to cut all the eigenvalues 1000 times lower than the largest eigenvalue
-            or np.inf to cut all the eigenvalues lower than zero
-
-        Returns
-        -------
-        `Pandas.Series`
-            real part of eigenvalues sorted in descending order
-        `pandas.DataFrame`
-            matrix of eigenvectors
-
-        Examples
-        --------
-        Extract eigenvalues of covariance matrix.
-        >>> sandy.CategoryCov([[1, 0.4], [0.4, 1]]).eig()[0]
-        0   1.40000e+00
-        1   6.00000e-01
-        Name: eigenvalues, dtype: float64
-        
-        >>> sandy.CategoryCov([[0.1, 0.1], [0.1, 1]]).eig()[0]
-        0   1.01098e+00
-        1   8.90228e-02
-        Name: eigenvalues, dtype: float64
-        
-        >>> sandy.CategoryCov([[0.1, 0.1], [0.1, 1]]).eig(tolerance=10)[0]
-        0   1.01098e+00
-        1   0.00000e+00
-        Name: eigenvalues, dtype: float64
-        
-        >>> sandy.CategoryCov([[1, 2], [2, 1]]).eig()[0]
-        0    3.00000e+00
-        1   -1.00000e+00
-        Name: eigenvalues, dtype: float64
-        
-        >>> sandy.CategoryCov([[1, 2], [2, 1]]).eig(tolerance=np.inf)[0]
-        0   3.00000e+00
-        1   0.00000e+00
-        Name: eigenvalues, dtype: float64
-
-        >>> Cov = sandy.CategoryCov.random_cov(50,seed=11)
-        >>> assert len(Cov.eig()[0]) == Cov.data.shape[0]
-
-        >>> sandy.CategoryCov([[1, 0.2, 0.1], [0.2, 2, 0], [0.1, 0, 3]]).eig()[0]
-        0   3.00509e+00
-        1   2.03815e+00
-        2   9.56764e-01
-        Name: eigenvalues, dtype: float64
-
-        >>> endf6 = sandy.get_endf6_file("jeff_33", "xs", 10010)
-        >>> err = endf6.get_errorr(ek=sandy.energy_grids.CASMO12, err=1)
-        >>> Cov = err.get_cov()
-        >>> assert len(Cov.eig()[0]) == Cov.data.shape[0]
-
-        Extract eigenfunctions of covariance matrix.
-        >>> sandy.CategoryCov([[1, 0.4], [0.4, 1]]).eig()[1]
-                    0            1
-        0 7.07107e-01 -7.07107e-01
-        1 7.07107e-01  7.07107e-01
-        """
-        E, V = scipy.linalg.eig(self.data)
-        E = pd.Series(E.real, name="eigenvalues")
-        V = pd.DataFrame(V.real)
-        if sort:
-            idx = E.sort_values(ascending=False).index
-            E = E.iloc[idx].reset_index(drop=True)
-            V = V.iloc[idx].reset_index(drop=True)
-        if tolerance:
-            indx = np.where(E.values < E.max() / tolerance)
-            E.values[indx] = 0
-        return E, V
-
     @property
     def std(self):
         """
@@ -396,6 +321,116 @@ class CategoryCov():
         cov = self.to_sparse().diagonal()
         std = np.sqrt(cov)
         return pd.Series(std, index=self.data.index, name="std")
+
+    def eig(self, tolerance=None):
+        """
+        Extract eigenvalues and eigenvectors.
+
+        Parameters
+        ----------
+        tolerance : `float`, optional, default is `None`
+            replace all eigenvalues smaller than a given tolerance with zeros.
+            The replacement comnidtion is implemented as,
+
+            .. math::
+                $$
+                \\fract{e_i}{e_{MAX}} < tolerance
+                $$
+
+            Then, a `tolerance=1e-3` will replace all eignevalues 
+            1000 times smaller smaller than the largest eigenvalue.
+            A `tolerance=0` will replace all negative eigenvalues.
+
+        Returns
+        -------
+        `Pandas.Series`
+            array of eigenvalues
+        `pandas.DataFrame`
+            matrix of eigenvectors
+
+        Notes
+        -----
+        .. note:: only the real part of the eigenvalues is preserved
+        
+        .. note:: the discussion associated to the implementeation
+                  of this algorithm is available [here](https://github.com/luca-fiorito-11/sandy/discussions/135)
+
+        Examples
+        --------
+        Extract eigenvalues of correlation matrix.
+        >>> sandy.CategoryCov([[1, 0.4], [0.4, 1]]).eig()[0]
+        0   1.40000e+00
+        1   6.00000e-01
+        Name: eigenvalues, dtype: float64
+
+        Extract eigenvectors of correlation matrix.
+        >>> sandy.CategoryCov([[1, 0.4], [0.4, 1]]).eig()[1]
+                    0            1
+        0 7.07107e-01 -7.07107e-01
+        1 7.07107e-01  7.07107e-01
+        
+        Extract eigenvalues of covariance matrix.
+        >>> sandy.CategoryCov([[0.1, 0.1], [0.1, 1]]).eig()[0]
+        0   8.90228e-02
+        1   1.01098e+00
+        Name: eigenvalues, dtype: float64
+        
+        Set up a tolerance.
+        >>> sandy.CategoryCov([[0.1, 0.1], [0.1, 1]]).eig(tolerance=0.1)[0]
+        0   0.00000e+00
+        1   1.01098e+00
+        Name: eigenvalues, dtype: float64
+        
+        Test with negative eigenvalues.
+        >>> sandy.CategoryCov([[1, 2], [2, 1]]).eig()[0]
+        0    3.00000e+00
+        1   -1.00000e+00
+        Name: eigenvalues, dtype: float64
+        
+        Replace negative eigenvalues.
+        >>> sandy.CategoryCov([[1, 2], [2, 1]]).eig(tolerance=0)[0]
+        0   3.00000e+00
+        1   0.00000e+00
+        Name: eigenvalues, dtype: float64
+
+        Check output size.
+        >>> cov = sandy.CategoryCov.random_cov(50, seed=11)
+        >>> assert cov.eig()[0].size == cov.data.shape[0] == 50
+
+        >>> sandy.CategoryCov([[1, 0.2, 0.1], [0.2, 2, 0], [0.1, 0, 3]]).eig()[0]
+        0   9.56764e-01
+        1   2.03815e+00
+        2   3.00509e+00
+        Name: eigenvalues, dtype: float64
+
+        Real test on H1 file
+        >>> endf6 = sandy.get_endf6_file("jeff_33", "xs", 10010)
+        >>> ek = sandy.energy_grids.CASMO12
+        >>> err = endf6.get_errorr(ek=ek, err=1)
+        >>> cov = err.get_cov()
+        >>> cov.eig()[0].sort_values(ascending=False).head(10)
+        0    3.66411e-01
+        1    7.05311e-03
+        2    1.55346e-03
+        3    1.60175e-04
+        4    1.81374e-05
+        5    1.81078e-06
+        6    1.26691e-07
+        7    6.03618e-10
+        8    4.74727e-11
+        11   6.46354e-12
+        Name: eigenvalues, dtype: float64
+        
+        >>> assert not (cov.eig()[0] >= 0).all()
+        
+        >>> assert (cov.eig(tolerance=0)[0] >= 0).all()
+        """
+        E, V = scipy.linalg.eig(self.data)
+        E = pd.Series(E.real, name="eigenvalues")
+        V = pd.DataFrame(V.real)
+        if tolerance is not None:
+            E[E/E.max() < tolerance] = 0
+        return E, V
 
     def get_corr(self):
         """
@@ -418,10 +453,11 @@ class CategoryCov():
             coeff = np.true_divide(1, self.std.values)
             coeff[~ np.isfinite(coeff)] = 0   # -inf inf NaN
         corr = np.multiply(np.multiply(cov, coeff).T, coeff)
-        return pd.DataFrame(corr,
-                            index=self.data.index,
-                            columns=self.data.columns,
-                            )
+        return pd.DataFrame(
+            corr,
+            index=self.data.index,
+            columns=self.data.columns,
+            )
 
     def _reduce_size(self):
         """
@@ -438,34 +474,23 @@ class CategoryCov():
         --------
         >>> S = sandy.CategoryCov(np.diag(np.array([1, 2, 3])))
         >>> non_zero_index, reduce_matrix = S._reduce_size()
-        >>> comparison = non_zero_index == np.array([0, 1, 2])
-        >>> equal_arrays = comparison.all()
-        >>> assert equal_arrays == True
-        >>> reduce_matrix
-                      0	          1	          2
-        0	1.00000e+00	0.00000e+00	0.00000e+00
-        1	0.00000e+00	2.00000e+00	0.00000e+00
-        2	0.00000e+00	0.00000e+00	3.00000e+00
+        >>> assert reduce_matrix.equals(S.data)
+        >>> assert (non_zero_index == range(3)).all()
 
         >>> S = sandy.CategoryCov(np.diag(np.array([0, 2, 3])))
         >>> non_zero_index, reduce_matrix = S._reduce_size()
-        >>> comparison = non_zero_index == np.array([1, 2])
-        >>> equal_arrays = comparison.all()
-        >>> assert equal_arrays == True
+        >>> assert (non_zero_index == np.array([1, 2])).all()
         >>> reduce_matrix
                     1           2
         1 2.00000e+00 0.00000e+00
         2 0.00000e+00 3.00000e+00
 
-        >>> S = sandy.CategoryCov(pd.DataFrame({'a':[0, 0, 0], 'b':[0, 2, 0], 'c':[0, 0, 3]}))
+        >>> S.data.index = S.data.columns = ["a", "b", "c"]
         >>> non_zero_index, reduce_matrix = S._reduce_size()
-        >>> comparison = non_zero_index == np.array([1, 2])
-        >>> equal_arrays = comparison.all()
-        >>> assert equal_arrays == True
         >>> reduce_matrix
                     b           c
-        1 2.00000e+00 0.00000e+00
-        2 0.00000e+00 3.00000e+00
+        b 2.00000e+00 0.00000e+00
+        c 0.00000e+00 3.00000e+00
         """
         nonzero_idxs = np.flatnonzero(np.diag(self.data))
         cov_reduced = self.data.iloc[nonzero_idxs, nonzero_idxs]
@@ -1645,7 +1670,7 @@ class CategoryCov():
         array([[ 1.171, -1.894],
                [-1.894,  3.065]])
         """
-        E, V = self.eig(sort=False)
+        E, V = self.eig()
         index = self.data.index
         columns = self.data.columns
         if (E >= 0).all():

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -151,7 +151,7 @@ class _Cov(np.ndarray):
         nonzero_idxs = np.flatnonzero(np.diag(self))
         cov_reduced = self[nonzero_idxs][:, nonzero_idxs]
         return nonzero_idxs, cov_reduced
-        
+
     @classmethod
     def _restore_size(cls, nonzero_idxs, cov_reduced, dim):
         """
@@ -1498,7 +1498,7 @@ class CategoryCov():
         0 2.15373e-02 5.97134e-03
         1 5.97134e-03 8.52642e-03
         """
-        corr = random_corr(size, correlations=correlations , seed=seed)
+        corr = random_corr(size, correlations=correlations, seed=seed)
         std = np.random.uniform(stdmin, stdmax, size)
         return cls.corr2cov(corr, std, **kwargs)
 
@@ -2451,8 +2451,7 @@ def random_corr(size, correlations=True, seed=None):
     np.random.seed(seed=seed)
     corr = np.eye(size)
     if correlations:
-        offdiag = np.random.uniform(-1, 1, size**2).reshape(size, size)
-        up = np.triu(offdiag, 1)
+        up = np.triu(np.random.uniform(-1, 1, size**2).reshape(size, size), 1)
     else:
         up = np.zeros([size, size])
     corr += up + up.T
@@ -2460,9 +2459,9 @@ def random_corr(size, correlations=True, seed=None):
 
 
 def random_cov(size, stdmin=0.0, stdmax=1.0, correlations=True, seed=None):
-        corr = random_corr(size, correlations=correlations , seed=seed)
-        std = np.random.uniform(stdmin, stdmax, size)
-        return corr2cov(corr, std)
+    corr = random_corr(size, correlations=correlations , seed=seed)
+    std = np.random.uniform(stdmin, stdmax, size)
+    return corr2cov(corr, std)
 
 
 def random_ctg_cov(index, stdmin=0.0, stdmax=1.0, correlations=True, seed=None):


### PR DESCRIPTION
The random_corr method implemented did not work for matrices with a dimention higher than 30x30 because it returned a matrix not always positive definite nor symettrical (for numerical fluctuations). With this correction the matrix will allow for the creation of a category cov instance up until size 10000x10000 (bigger matrix gives memory issues, in the previous implementation as well), but some eigenvalues could be `-1e-18` or in this range (numerical approximation of zero).  

The method  _reduce_size is modified because it did not work for a real covariance matrix. 

P.s. even if we will change the decomposition it should be mantained because it is used also for different methods (invert, _gls_G_inv)