### PR TITLE
_get_edistr_cov method + bug solve

### DIFF
--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -2395,9 +2395,8 @@ def segmented_pivot_table(data_stack, index, columns, values, rows=10000000):
             index=index,
             columns=columns,
             values=values,
-            fill_value=0,
             aggfunc=np.sum,
-            )
+            ).fillna(0)
         pivot_matrix.append(partial_pivot)
     pivot_matrix = pd.concat(pivot_matrix).fillna(0)
     # Because the default axis to concatenate is the 0, some duplicate

--- a/sandy/core/endf6.py
+++ b/sandy/core/endf6.py
@@ -2475,3 +2475,66 @@ If you want to process 0K cross sections use `temperature=0.1`.
             'chi': run_chi if chi else False,
             }
         return cov_info
+
+    def _get_edistr_cov(self, mt=range(1, 10000), mat=range(1, 10000)):
+        """
+        Extract energy distribution coefficients covariance matrix
+        from `sandy.Endf6` instance.
+
+        Parameters
+        ----------
+        mat : `int`, optional
+            MAT number. The default is None.
+        mt : `int`, optional
+            MT number. The default is None.
+
+        Returns
+        -------
+        `sandy.CategoryCov`
+            Covariance matrix.
+
+        """
+        listmt_ = [mt] if isinstance(mt, int) else mt
+        listmat_ = [mat] if isinstance(mat, int) else mat
+        tape = self.filter_by(listmf=[35],
+                              listmt=listmt_,
+                              listmat=listmat_)
+        data = []
+        for mat, mf, mt in tape.data:
+            sec = tape.read_section(mat, mf, mt)
+            for sub, sub_info in sec["SUB"].items():
+                Ek = np.array(sub_info["EK"])
+                Fkk = np.array(sub_info["FKK"])
+                NE = sub_info["NE"]
+                # Covariance
+                cov_upper = np.zeros([NE-1, NE-1])
+                indices = np.triu_indices(NE-1)
+                cov_upper[indices] = Fkk
+                cov = sandy.cov.triu_matrix(cov_upper).data.values
+                # Normalize covariance matrix dividing by the energy bin.
+                dE = 1./(Ek[1:]-Ek[:-1])
+                cov = sandy.cov.corr2cov(cov, dE)
+                # Add zero row and column at the end of the matrix
+                cov = np.insert(cov, cov.shape[0], [0]*cov.shape[1], axis=0)
+                cov = np.insert(cov, cov.shape[1], [0]*cov.shape[0], axis=1)
+                # multiindex:
+                index = pd.MultiIndex.from_product(
+                    [[mat], [mt], [sub_info["ELO"]], [sub_info["EHI"]], Ek],
+                    names=["MAT", "MT", "ELO", "EHI", "E"],
+                )
+                columns = pd.MultiIndex.from_product(
+                    [[mat], [mt], [sub_info["ELO"]], [sub_info["EHI"]], Ek],
+                    names=["MAT1", "MT1", "ELO1", "EHI1", "E1"],
+                )
+                df = pd.DataFrame(cov,
+                                  index=index,
+                                  columns=columns)\
+                       .stack(level=["MAT1", "MT1", "ELO1", "EHI1", "E1"])\
+                       .rename("VAL").reset_index()
+                data.append(df)
+        data = pd.concat(data)
+        return sandy.CategoryCov.from_stack(data,
+                                            index=["MAT", "MT", "ELO", "EHI", "E"],
+                                            columns=["MAT1", "MT1", "ELO1", "EHI1", "E1"],
+                                            values='VAL',
+                                            kind='all')


### PR DESCRIPTION
`_get_edistr_cov`: The function now works with the way sandy is written. Also, the test of this function will go with a notebook, because the correlation matrices are available in JANIS.  

`segmented_pivot_table` bug: The method `pivot_table(fill_values=0)` doesnt work properly with very small values (<10e-25), but `pivot_table.fillna(0)` works properly