### PR TITLE
CategoryCov invert

### DIFF
--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -527,13 +527,13 @@ class CategoryCov():
         """
         Test method get a covariance matrix without negative eigs.
         BEcause of the properties of pinv, this should be equivalent to
-        reconstructing the matrix as `V @ E @ V`, where `V` are the
+        reconstructing the matrix as `V @ E @ V^T`, where `V` are the
         eigenvectors and `E` are truncated eigenvalues.
 
         Returns
         -------
         `sandy.CategoryCov`
-            matrix without problematic eigenvalues
+            inverse of the inverted matrix
 
         Test on real ND covariance.
         >>> c = sandy.get_endf6_file("jeff_33", "xs", 10010).get_errorr(err=1, mt=[102]).get_cov(multigroup=False)

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -477,9 +477,6 @@ class CategoryCov():
     def invert(self):
         """
         Method for calculating the inverse matrix.
-        If zeros are found on the matrix diagonal, the corresponding rows and columns
-        are removed to invert a non-singolar matrix.
-        The zeros are put back into place in the inverted matrix.
 
         Returns
         -------
@@ -488,13 +485,15 @@ class CategoryCov():
 
         Notes
         -----
-        Many covariance matrices for nuclear data are ill-defined and might have condition numbers that
-        make the matrix inversion process impossible.
-        To make up for this limitation we produce the (Moore-Penrose) pseudo-inverse of a Hermitian
-        matrix, as implemented in scipy.
+        Many covariance matrices for nuclear data are ill-defined and might
+        have condition numbers that make the matrix inversion process
+        impossible.
+        To make up for this limitation we produce the (Moore-Penrose)
+        pseudo-inverse of a Hermitian matrix, as implemented in `numpy`.
         Default options are used.
-        This method does not require any pre-processing of the covariance data, e.g. removing zeros
-        from the matrix diagonal or truncating eigenvalues.
+        This method does not require any pre-processing of the covariance
+        data, e.g. removing zeros from the matrix diagonal or truncating
+        eigenvalues.
         
         >>> c = sandy.CategoryCov(np.diag(np.array([1, 2, 3])))
         >>> c.invert()


### PR DESCRIPTION
This PR follows issue #237.

The following modifications were implemented:
 - the algorithm in method `CategoryCov.invert` was replaced with [numpy.linalg.pinv](https://numpy.org/doc/stable/reference/generated/numpy.linalg.pinv.html) for Hermitian matrices .
 - a private method `CategoryCov._double_invert` was implemented for debugging to calculate the inverse of an inverted matrix 