### PR TITLE
Fix sampling unit tests

### DIFF
--- a/notebooks/notebook_shapiro.ipynb
+++ b/notebooks/notebook_shapiro.ipynb
@@ -1,0 +1,263 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cfc7bba9",
+   "metadata": {},
+   "source": [
+    "# Shapiro-Wilk test for normal and lognormal distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e456eaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sandy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35fae75e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import pandas as pd\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e08433c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c57f6407",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logging.getLogger().setLevel(logging.WARN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d1ddd57",
+   "metadata": {},
+   "source": [
+    "Generate 5000 xs samples normally and log-normally distributed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa73bbbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tape = sandy.get_endf6_file(\"jeff_33\", \"xs\", 10010)\n",
+    "njoy_kws = dict(err=1, errorr33_kws=dict(mt=102))\n",
+    "nsmp = 5000\n",
+    "seed = 5\n",
+    "\n",
+    "smp_norm = tape.get_perturbations(nsmp, njoy_kws=njoy_kws, smp_kws=dict(seed33=seed, pdf=\"normal\"))[33]\n",
+    "smp_lognorm = tape.get_perturbations(nsmp, njoy_kws=njoy_kws, smp_kws=dict(seed33=seed, pdf=\"lognormal\"))[33]\n",
+    "smp_uniform = tape.get_perturbations(nsmp, njoy_kws=njoy_kws, smp_kws=dict(seed33=seed, pdf=\"uniform\"))[33]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08f12802",
+   "metadata": {},
+   "source": [
+    "##  Shapiro-Wilk test normal samples and normal distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cf664f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stat_norm = []\n",
+    "stat_lognorm = []\n",
+    "for n in [10, 50, 100, 500, 1000, 5000]:\n",
+    "    df = smp_norm.test_shapiro(pdf=\"normal\", size=n)\n",
+    "    idx = df.statistic.idxmin()\n",
+    "    stat_norm.append(df.loc[idx].rename(n))\n",
+    "\n",
+    "    df = smp_norm.test_shapiro(pdf=\"lognormal\", size=n)\n",
+    "    idx = df.statistic.idxmin()\n",
+    "    stat_lognorm.append(df.loc[idx].rename(n))\n",
+    "\n",
+    "opts = dict(left_index=True, right_index=True, suffixes=(\"_norm\", \"_lognorm\"))\n",
+    "pd.DataFrame(stat_norm).merge(pd.DataFrame(stat_lognorm), **opts).rename_axis(\"# SMP\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "449bdf7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = smp_norm.test_shapiro(pdf=\"normal\", size=5000)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 4), dpi=100)\n",
+    "\n",
+    "idx = test.statistic.idxmin()\n",
+    "w = test.loc[idx]\n",
+    "sns.histplot(data=smp_norm.data.loc[idx], label=f\"W:stat={w.statistic:.2e}, p-value={w.pvalue:.2e}\", color=\"dodgerblue\")\n",
+    "\n",
+    "idx = test.statistic.idxmax()\n",
+    "w = test.loc[idx]\n",
+    "sns.histplot(data=smp_norm.data.loc[idx], label=f\"W:stat={w.statistic:.2e}, p-value={w.pvalue:.2e}\", color=\"tomato\")\n",
+    "\n",
+    "ax.set(xlabel=\"W\")\n",
+    "ax.legend()\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78c3e97d",
+   "metadata": {},
+   "source": [
+    "## Shapiro-Wilk test for lognormal samples and lognormal distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be16d4f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stat_norm = []\n",
+    "stat_lognorm = []\n",
+    "for n in [10, 50, 100, 500, 1000, 5000]:\n",
+    "    df = smp_lognorm.test_shapiro(pdf=\"normal\", size=n)\n",
+    "    idx = df.statistic.idxmin()\n",
+    "    stat_norm.append(df.loc[idx].rename(n))\n",
+    "\n",
+    "    df = smp_lognorm.test_shapiro(pdf=\"lognormal\", size=n)\n",
+    "    idx = df.statistic.idxmin()\n",
+    "    stat_lognorm.append(df.loc[idx].rename(n))\n",
+    "\n",
+    "opts = dict(left_index=True, right_index=True, suffixes=(\"_norm\", \"_lognorm\"))\n",
+    "pd.DataFrame(stat_norm).merge(pd.DataFrame(stat_lognorm), **opts).rename_axis(\"# SMP\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fa36199",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = smp_lognorm.test_shapiro(pdf=\"lognormal\", size=5000)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 4), dpi=100)\n",
+    "\n",
+    "idx = test.statistic.idxmin()\n",
+    "w = test.loc[idx]\n",
+    "sns.histplot(data=smp_lognorm.data.loc[idx], label=f\"W:stat={w.statistic:.2e}, p-value={w.pvalue:.2e}\", color=\"dodgerblue\")\n",
+    "\n",
+    "idx = test.statistic.idxmax()\n",
+    "w = test.loc[idx]\n",
+    "sns.histplot(data=smp_lognorm.data.loc[idx], label=f\"W:stat={w.statistic:.2e}, p-value={w.pvalue:.2e}\", color=\"tomato\")\n",
+    "\n",
+    "ax.set(xlabel=\"W\")\n",
+    "ax.legend()\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "975dbaa1",
+   "metadata": {},
+   "source": [
+    "## Shapiro-Wilk test for uniform samples and normal distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bded2114",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stat_norm = []\n",
+    "stat_lognorm = []\n",
+    "for n in [10, 50, 100, 500, 1000, 5000]:\n",
+    "    df = smp_uniform.test_shapiro(pdf=\"normal\", size=n)\n",
+    "    idx = df.statistic.idxmin()\n",
+    "    stat_norm.append(df.loc[idx].rename(n))\n",
+    "\n",
+    "    df = smp_uniform.test_shapiro(pdf=\"lognormal\", size=n)\n",
+    "    idx = df.statistic.idxmin()\n",
+    "    stat_lognorm.append(df.loc[idx].rename(n))\n",
+    "\n",
+    "opts = dict(left_index=True, right_index=True, suffixes=(\"_norm\", \"_lognorm\"))\n",
+    "pd.DataFrame(stat_norm).merge(pd.DataFrame(stat_lognorm), **opts).rename_axis(\"# SMP\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6e1d4ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = smp_uniform.test_shapiro(pdf=\"uniform\", size=5000)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 4), dpi=100)\n",
+    "\n",
+    "idx = test.statistic.idxmin()\n",
+    "w = test.loc[idx]\n",
+    "sns.histplot(data=smp_uniform.data.loc[idx], label=f\"W:stat={w.statistic:.2e}, p-value={w.pvalue:.2e}\", color=\"dodgerblue\")\n",
+    "\n",
+    "idx = test.statistic.idxmax()\n",
+    "w = test.loc[idx]\n",
+    "sns.histplot(data=smp_uniform.data.loc[idx], label=f\"W:stat={w.statistic:.2e}, p-value={w.pvalue:.2e}\", color=\"tomato\")\n",
+    "\n",
+    "ax.set(xlabel=\"W\")\n",
+    "ax.legend()\n",
+    "fig.tight_layout()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python3 (sandy-devel)",
+   "language": "python",
+   "name": "sandy-devel"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -244,6 +244,8 @@ class CategoryCov():
         deviation vector
     from_stack
         create a covariance matrix from a stacked `pd.DataFrame`
+    from_stdev
+        construct a covariance matrix from a standard deviation vector
     from_var
         construct a covariance matrix from a variance vector
     get_corr
@@ -376,6 +378,36 @@ class CategoryCov():
         corr = random_corr(size, correlations=correlations, seed=seed)
         std = np.random.uniform(stdmin, stdmax, size)
         return CategoryCov(corr).corr2cov(std)
+
+    @classmethod
+    def from_stdev(cls, std):
+        """
+        Construct the covariance matrix from the standard deviation vector.
+
+        Parameters
+        ----------
+        var : 1D iterable
+            Standar deviation vector.
+
+        Returns
+        -------
+        `CategoryCov`
+            Object containing the covariance matrix.
+
+        Example
+        -------
+        Create covariance from stdev in `pd.Series`.
+        >>> var = pd.Series(np.array([0, 2, 3]), index=pd.Index(["A", "B", "C"]))
+        >>> std = np.sqrt(var)
+        >>> cov = sandy.CategoryCov.from_stdev(std)
+        >>> cov
+                    A           B           C
+        A 0.00000e+00 0.00000e+00 0.00000e+00
+        B 0.00000e+00 2.00000e+00 0.00000e+00
+        C 0.00000e+00 0.00000e+00 3.00000e+00
+        """
+        std_ = pd.Series(std)
+        return cls.from_var(std_ * std_)
 
     @classmethod
     def from_var(cls, var):

--- a/sandy/core/endf6.py
+++ b/sandy/core/endf6.py
@@ -2070,7 +2070,6 @@ class Endf6(_FormattedFile):
             smp[31] = outs["errorr31"].get_cov().sampling(nsmp, **smp_kws)
         if "errorr33" in outs:
             smp_kws["seed"] = smp_kws.get("seed33", None)
-            print(smp_kws)
             smp[33] = outs["errorr33"].get_cov().sampling(nsmp, **smp_kws)
         if to_excel and smp:
             with pd.ExcelWriter(to_excel) as writer:

--- a/sandy/core/samples.py
+++ b/sandy/core/samples.py
@@ -154,7 +154,7 @@ class Samples():
         ...             df = smps.test_shapiro(pdf=pdf, size=n)
         ...             idx = df.statistic.idxmin()
         ...             w = df.loc[idx]
-        ...             t = "reject" if w.pvalue < pthreshold else (pdf if w.statistic > threshold else f"not-{pdf}")
+        ...             t = "reject" if w.pvalue < pthreshold else (pdf if w.statistic > threshold else "reject")
         ...             data.append({"PDF": pdf, "test":t, "# SMP": n})
         ...     df = pd.DataFrame(data).pivot_table(index="# SMP", columns="PDF", values="test", aggfunc=lambda x: ' '.join(x))
         ...     return df

--- a/sandy/core/samples.py
+++ b/sandy/core/samples.py
@@ -163,7 +163,7 @@ class Samples():
         >>> print(test(smp_norm))
         PDF   lognormal      normal
         # SMP                      
-        10       reject  not-normal
+        10       reject      reject
         50       reject      reject
         100      reject      reject
         500      reject      reject

--- a/sandy/core/samples.py
+++ b/sandy/core/samples.py
@@ -16,17 +16,25 @@ class Samples():
     
     Attributes
     ----------
-    condition_number
-        
     data
-        
+        Dataframe of samples.
 
     Methods
     -------
-    filter_by
-        
-    from_csv
-       
+    get_condition_number
+        Return condition number of samples.
+    get_cov
+        Return covariance matrix of samples.
+    get_mean
+        Return mean vector of samples.
+    get_std
+        Return standard deviation vector of samples.
+    get_rstd
+        Return relative standard deviation vector of samples.   
+    iterate_xs_samples
+        Generator that iterates over each sample (in the form of :func:`sandy.Xs`).
+    test_shapiro
+        Perform the Shapiro-Wilk test for normality on the samples.
     """
 
     _columnsname = "SMP"
@@ -62,8 +70,7 @@ class Samples():
     def data(self, data):
         self._data = data.rename_axis(self.__class__._columnsname, axis=1)
 
-    @property
-    def condition_number(self):
+    def get_condition_number(self):
         """
         Return condition number of samples.
 
@@ -116,19 +123,27 @@ class Samples():
     
     def test_shapiro(self, size=None, pdf="normal"):
         """
+        Perform the Shapiro-Wilk test for normality on the samples.
+        The test can be performed also for a lognormal distribution by testing
+        for normality the logarithm of the samples.
         
+        The Shapiro-Wilk test tests the null hypothesis that the data was
+        drawn from a normal distribution.
 
         Parameters
         ----------
-        size : TYPE, optional
-            DESCRIPTION. The default is None.
-        pdf : TYPE, optional
-            DESCRIPTION. The default is "normal".
+        size : `int`, optional
+            number of samples (starting from the first) that need to be
+            considered for the test. The default is `None`, i.e., all samples.
+        pdf : `str`, optional
+            the pdf used to test the samples. Either `"normal"` or
+            `"lognormal"`. The default is "normal".
 
         Returns
         -------
-        TYPE
-            DESCRIPTION.
+        pd.DataFrame
+            Dataframe with Shapriro-Wilk results (statistic and pvalue) for
+            each variable considered in the :func:`~Samples` instance.
 
         Examples
         --------
@@ -195,7 +210,7 @@ class Samples():
         size_ = size or self.data.shape[1]
         names = ["statistic", "pvalue"]
 
-        data = self.data.loc[:, :size_]
+        data = self.data.iloc[:, :size_]
         if pdf.lower() == "lognormal":
             data = np.log(self.data)
 

--- a/sandy/sampling.py
+++ b/sandy/sampling.py
@@ -191,6 +191,7 @@ def run(cli):
     Produce perturbed ENDF6 and PENDF files.
     >>> cli = "H1.jeff33 --samples 2 --processes 2 --outname=H1_{MAT}_{SMP} --mt 102"
     >>> sandy.sampling.run(cli)
+    >>> os.listdir()
 
     >>> assert filecmp.cmp("H1_125_0.endf6", "H1_125_1.endf6")
     >>> assert filecmp.cmp("H1_125_0.endf6", "H1.jeff33")

--- a/sandy/sampling.py
+++ b/sandy/sampling.py
@@ -191,7 +191,7 @@ def run(cli):
     Produce perturbed ENDF6 and PENDF files.
     >>> cli = "H1.jeff33 --samples 2 --processes 2 --outname=H1_{MAT}_{SMP} --mt 102"
     >>> sandy.sampling.run(cli)
-    >>> os.listdir()
+    >>> assert os.path.getsize("H1_125_0.pendf") > 0 and os.path.getsize("H1_125_1.pendf") > 0
 
     >>> assert filecmp.cmp("H1_125_0.endf6", "H1_125_1.endf6")
     >>> assert filecmp.cmp("H1_125_0.endf6", "H1.jeff33")


### PR DESCRIPTION
Fixing issue with unit test in `sandy.Samples.test_shapiro` producing different outputs on windows and linux.
The differences are likely to originate from different compilations of the fortran functions called by `scipy.stats.shapiro`.

The test is converted into a notebook.

A different test based on the p-value is implemented instead.