### PR TITLE
Fix write_float edge case, which crashes NJOY

### DIFF
--- a/sandy/core/records.py
+++ b/sandy/core/records.py
@@ -315,7 +315,7 @@ def write_float(x):
         y = f"{x:11.0f}"
     elif x == 0:
         y = f"{x:11.8f}"
-    elif abs(x) < 1E0 and abs(x) >= 0.99999996:
+    elif abs(x) < 1E0 and abs(x) > 0.99999995:
         y = f"{x:13.6e}".replace("e+00", "")
     elif abs(x) < 1E0 and abs(x) >= 1e-9:
         y = f"{x:13.6e}".replace("e-0", "-")

--- a/sandy/core/records.py
+++ b/sandy/core/records.py
@@ -315,6 +315,8 @@ def write_float(x):
         y = f"{x:11.0f}"
     elif x == 0:
         y = f"{x:11.8f}"
+    elif abs(x) < 1E0 and abs(x) >= 0.99999996:
+        y = f"{x:13.6e}".replace("e+00", "")
     elif abs(x) < 1E0 and abs(x) >= 1e-9:
         y = f"{x:13.6e}".replace("e-0", "-")
     else:


### PR DESCRIPTION
There is a strange edge case in `write_float` where

```python
sandy.records.write_float(0.99999995) 
' 9.999999-1'
```
but
```python
sandy.records.write_float(0.99999996) 
' 1.000000e+00'
```

Likely because the string interpolation `f"{x:13.6e}"` is rounding up to ` 1.000000e+00`, and it isn't caught as a case in the function. 

This was giving an annoying error from NJOY `Fortran runtime error: Bad value during floating point read`, where these strings end up in generated pendf files, and are unable to be read by NJOY.
