### PR TITLE
Fix absolute to relative in notebook_sampling_ify_u235th_cea_c1.ipynb

### DIFF
--- a/notebooks/notebook_sampling_ify_u235th_cea_c1.ipynb
+++ b/notebooks/notebook_sampling_ify_u235th_cea_c1.ipynb
@@ -46,9 +46,11 @@
     "\n",
     "idx = nfpy.data.query(f\"E==0.0253 & MT==454\").index\n",
     "ifyth = nfpy.data.loc[idx]\n",
+    "IFY_np = np.array([ifyth['FY'].to_numpy()])\n",
     "\n",
     "cov = pd.read_csv(join(path, file_cov), sep=r\"\\s+\", header=None)\n",
-    "cov.index = cov.columns = pd.Index(ifyth.ZAP)\n",
+    "cov = np.divide(cov.data.to_numpy(), IFY_np.T @ IFY_np) # convert to relative terms\n",
+    "cov = pd.DataFrame(cov, index = pd.Index(ifyth.ZAP), columns = pd.Index(ifyth.ZAP))\n",
     "cov = sandy.CategoryCov(cov)"
    ]
   },


### PR DESCRIPTION
I have divided the absolute covariance matrix elementwise by the correct independent fission yields to convert it to a relative covariance matrix to draw samples from.