### PR TITLE
Fix a test which randomly makes pytest fail

### DIFF
--- a/sandy/sampling.py
+++ b/sandy/sampling.py
@@ -199,7 +199,7 @@ def multi_run(foo):
     >>> assert "1001.09c" in open("1001_0.09c.xsd").read()
     >>> assert "1001.09c" in open("1001_1.09c").read()
     >>> assert "1001.09c" in open("1001_1.09c.xsd").read()
-    >>> assert not filecmp.cmp("1001_0.09c", "1001_1.09c")
+    >>> assert not filecmp.cmp("1001_0.09c", "1001_1.09c", shallow=False)
 
     Run the same on a single process.
     >>> cli = "H1.jeff33 --acer True --samples 2 --processes 2 --temperatures 900 --seed33 5 --outname={ZAM}_{SMP}_SP"


### PR DESCRIPTION
In `sandy.sampling.multi_run`, there is a test that when generating two samples with two processes, the resulting files are differents. However the comparison function is parametrized with `shallow = True`, in the event that the files are created by the two processed at the same time, the assert will fail.

As a result, pytest runs randomly fail.

This PR fixes this issue by setting `shallow = False` in the test 