### PR TITLE
Explicitely using openpyxl as default engine for writing to excel

### DIFF
--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -622,7 +622,7 @@ class CategoryCov():
 
         # -- Save seed and singulare values
         if to_excel:
-            with pd.ExcelWriter(to_excel, mode='w') as writer:
+            with pd.ExcelWriter(to_excel, mode='w', engine='openpyxl') as writer:
                 pd.Series(seed_).to_excel(writer, header=None, index=None, sheet_name='SEED')
                 pd.Series(Sr).to_excel(writer, header=None, index=None, sheet_name='SVALUES')
 

--- a/sandy/core/cov.py
+++ b/sandy/core/cov.py
@@ -647,7 +647,7 @@ class CategoryCov():
 
         # -- Save samples
         if to_excel:
-            with pd.ExcelWriter(to_excel, mode='a') as writer:
+            with pd.ExcelWriter(to_excel, mode='a', engine="openpyxl") as writer:
                 # this might go into Samples
                 s = samples.reset_index()
                 loc = s.columns.get_loc("E")


### PR DESCRIPTION
On my machine, running a sandy calculation using tag v1.1 fails with the following message 

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/nlinden/.pyenv/versions/3.11.4/lib/python3.11/site-packages/sandy/sampling.py", line 406, in <module>
    run()
  File "/home/nlinden/.pyenv/versions/3.11.4/lib/python3.11/site-packages/sandy/sampling.py", line 279, in inner
    out = foo(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^
  File "/home/nlinden/.pyenv/versions/3.11.4/lib/python3.11/site-packages/sandy/sampling.py", line 267, in inner
    return foo(iargs)
           ^^^^^^^^^^
  File "/home/nlinden/.pyenv/versions/3.11.4/lib/python3.11/site-packages/sandy/sampling.py", line 363, in run
    smps = endf6.get_perturbations(iargs.samples, njoy_kws=errorr_kws, smp_kws=smp_kws)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nlinden/.pyenv/versions/3.11.4/lib/python3.11/site-packages/sandy/core/endf6.py", line 2135, in get_perturbations
    smp[31] = outs["errorr31"].get_cov().sampling(nsmp, to_excel=xls, seed=smp_kws.get("seed31"), **smp_kws)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nlinden/.pyenv/versions/3.11.4/lib/python3.11/site-packages/sandy/core/cov.py", line 650, in sampling
    with pd.ExcelWriter(to_excel, mode='a') as writer:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nlinden/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pandas/io/excel/_xlsxwriter.py", line 202, in __init__
    raise ValueError("Append mode is not supported with xlsxwriter!")
ValueError: Append mode is not supported with xlsxwriter!
```

this is due to pandas using `xlsxwriter` rather than `openpyxl` by default if both are installed. (see [this](https://pandas.pydata.org/docs/reference/api/pandas.ExcelWriter.html)). 

To ensure `openpyxl` is always used, I explicitely tell `pd.ExcelWriter` to use it.