### PR TITLE
Change deprecated pandas construct

### DIFF
--- a/sandy/core/samples.py
+++ b/sandy/core/samples.py
@@ -203,8 +203,8 @@ class Samples():
         df = self.data.unstack(level=levels)
         
         # -- Iterate over samples
-        for n, p in df.groupby(axis=1, level=self._columnsname):
-            s = p.droplevel(self._columnsname, axis=1)
+        for n, p in df.T.groupby(level=self._columnsname):
+            s = p.T.droplevel(self._columnsname, axis=1)
             adds = []
             for mat in s.columns.get_level_values("MAT").unique():
                 

--- a/sandy/core/xs.py
+++ b/sandy/core/xs.py
@@ -415,8 +415,8 @@ class Xs():
         >>> assert xsr.data[(9543, 4)].equals(xsr.data[9543].loc[:, 50:91].sum(axis=1))
         """
         df = self.data.copy()
-        for mat, group in df.groupby("MAT", axis=1):
-        
+        for mat, group_ in df.T.groupby("MAT"):
+            group = group_.T
             # starting from the lat redundant cross section, find daughters and sum them
             for parent, daughters in sorted(sandy.redundant_xs.items(), reverse=True):
                 # it must be df, not group, because df is updated


### PR DESCRIPTION
The axis argument is the `pandas.DataFrame.groupby` is deprecated is will be removed according to [this](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html). This causes warnings to be raised with recent python/pandas versions.

The recommended alternative is to use transposition before `groupby`. This PR implements this fix.