### PR TITLE
Fix regex string syntax by using raw string literals (r"")

### DIFF
--- a/sandy/aleph2/fy_output.py
+++ b/sandy/aleph2/fy_output.py
@@ -26,7 +26,7 @@ def read_fy_output(file):
     df : `pandas.DataFrame`
         dataframe with fission yields.
     """
-    df = pd.read_csv(file, sep='\s+', skiprows=1, index_col=0).iloc[:-1]
+    df = pd.read_csv(file, sep=r'\s+', skiprows=1, index_col=0).iloc[:-1]
     df.index.name = "DAUGHTER"
     df.index = df.index.astype(int)
     df.columns.name = "PARENT"

--- a/sandy/aleph2/output_file.py
+++ b/sandy/aleph2/output_file.py
@@ -22,48 +22,48 @@ from sandy.utils import grouper
 
 
 summary_header = "\n".join((
-    "\*" * 80,
-    "\*                            ALEPH problem summary                             \*",
-    "\*" * 80,
+    r"\*" * 80,
+    r"\*                            ALEPH problem summary                             \*",
+    r"\*" * 80,
 ))
 
 table_header = "\n".join((
-    "\*" * 80,
-    "\*\-\-\- Table (?P<table_number>[0-9\s]{2}) \-\-\- (?P<table_name>.*?)\*",
-    "\*" * 80,
+    r"\*" * 80,
+    r"\*\-\-\- Table (?P<table_number>[0-9\s]{2}) \-\-\- (?P<table_name>.*?)\*",
+    r"\*" * 80,
 ))
-material_header = "\*\*\*\*\*   Material (?P<material_number>[0-9\s]{7})\n"
-element_header = "\*\*\*\*\*   Per element.*\n"
-contributor_header = "Main contributors.*\n\n\n"
-info_header = "\*+\n\n\nALEPH info:"
+material_header = r"\*\*\*\*\*   Material (?P<material_number>[0-9\s]{7})\n"
+element_header = r"\*\*\*\*\*   Per element.*\n"
+contributor_header = r"Main contributors.*\n\n\n"
+info_header = r"\*+\n\n\nALEPH info:"
 
-table_footer = "^\s+Total"
+table_footer = r"^\s+Total"
 
-PATTERN_TIMEKEFF = re.compile("\s+Global neutronics parameters\n\s+\-+\n\s+Time\s+\((?P<unit>[a-z]+)\)\s+(?P<data>.*?)\n")
-PATTERN_BURNUP = re.compile("^\sFuel burnup \(MWd/kg HM\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_KEFF = re.compile("^\s+Keff  eff. mult. factor\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_KEFF_NPS = re.compile("^\s+Keff estimate NPS problem\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_DKEFF = re.compile("^\s+Relative std. deviation\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_TIMEKEFF = re.compile(r"\s+Global neutronics parameters\n\s+\-+\n\s+Time\s+\((?P<unit>[a-z]+)\)\s+(?P<data>.*?)\n")
+PATTERN_BURNUP = re.compile(r"^\sFuel burnup \(MWd/kg HM\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_KEFF = re.compile(r"^\s+Keff  eff. mult. factor\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_KEFF_NPS = re.compile(r"^\s+Keff estimate NPS problem\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_DKEFF = re.compile(r"^\s+Relative std. deviation\s+(?P<data>.*?)$", flags=re.MULTILINE)
 
-PATTERN_MAT_BEGIN = re.compile("\s+Irradiated materials\n\s+\-{20}")
-PATTERN_MAT_END = re.compile("\s+\*{28}\n\s+\* Total over all materials \*\n\s+\*{28}")
+PATTERN_MAT_BEGIN = re.compile(r"\s+Irradiated materials\n\s+\-{20}")
+PATTERN_MAT_END = re.compile(r"\s+\*{28}\n\s+\* Total over all materials \*\n\s+\*{28}")
 
-PATTERN_MATERIAL = re.compile("^\*{5}\s+Material\s+(?P<mat>.*?)$", flags=re.MULTILINE)
-PATTERN_CELLS = re.compile("\n\n\s+Cells\s+=\s+(?P<data>(?:[0-9, ]+\n)+)\n")
-PATTERN_VOLUME = re.compile("^\s+Volumes \(cm3\)\s+=\s+(?P<data>.*?) $", flags=re.MULTILINE)
+PATTERN_MATERIAL = re.compile(r"^\*{5}\s+Material\s+(?P<mat>.*?)$", flags=re.MULTILINE)
+PATTERN_CELLS = re.compile(r"\n\n\s+Cells\s+=\s+(?P<data>(?:[0-9, ]+\n)+)\n")
+PATTERN_VOLUME = re.compile(r"^\s+Volumes \(cm3\)\s+=\s+(?P<data>.*?) $", flags=re.MULTILINE)
 
-PATTERN_TIME = re.compile("^\s+Time\s+\((?P<unit>[a-z]+)\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_WDENSITY = re.compile("^\s+Density\s+\(g/cm3\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_ADENSITY = re.compile("^\s+Density\s+\(at/\(b\*cm\)\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_TEMPERATURE = re.compile("^\s+Temperature\s+\(K\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_SOURCE = re.compile("^\s+Source strength\s+\(part/s\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_NFLUX = re.compile("^\s+Neutron flux\s+\(n/\(cm2\*s\)\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_HFLUX = re.compile("^\s+Proton flux\s+\(h/\(cm2\*s\)\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_POWER = re.compile("^\s+Thermal power\s+\(MW\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_BURNUP = re.compile("^\s+Fuel burnup\s+\(MWd/kg HM\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_TOTBURNUP = re.compile("^\s+Total burnup \(MWd/kg HM\):\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_FISSIONS = re.compile("^\s+Integral number of fissions\s+(?P<data>.*?)$", flags=re.MULTILINE)
-PATTERN_TOTFISSIONS = re.compile("^\s+Total number of fissions:\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_TIME = re.compile(r"^\s+Time\s+\((?P<unit>[a-z]+)\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_WDENSITY = re.compile(r"^\s+Density\s+\(g/cm3\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_ADENSITY = re.compile(r"^\s+Density\s+\(at/\(b\*cm\)\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_TEMPERATURE = re.compile(r"^\s+Temperature\s+\(K\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_SOURCE = re.compile(r"^\s+Source strength\s+\(part/s\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_NFLUX = re.compile(r"^\s+Neutron flux\s+\(n/\(cm2\*s\)\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_HFLUX = re.compile(r"^\s+Proton flux\s+\(h/\(cm2\*s\)\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_POWER = re.compile(r"^\s+Thermal power\s+\(MW\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_BURNUP = re.compile(r"^\s+Fuel burnup\s+\(MWd/kg HM\)\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_TOTBURNUP = re.compile(r"^\s+Total burnup \(MWd/kg HM\):\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_FISSIONS = re.compile(r"^\s+Integral number of fissions\s+(?P<data>.*?)$", flags=re.MULTILINE)
+PATTERN_TOTFISSIONS = re.compile(r"^\s+Total number of fissions:\s+(?P<data>.*?)$", flags=re.MULTILINE)
 
 MATERIAL_KEYS = [
     "ID",
@@ -502,7 +502,7 @@ def parse_output_for_tables(text, index="ZAM"):
             string = io.StringIO(lines[0])
             columns = pd.read_csv(
                 string,
-                sep="\s+",
+                sep=r"\s+",
                 header=None,
                 index_col=0,
                 ).iloc[:, 1:].squeeze()
@@ -511,7 +511,7 @@ def parse_output_for_tables(text, index="ZAM"):
                 string = io.StringIO("\n".join(lines[begin:]))
                 df = pd.read_csv(
                     string,
-                    sep="\s+",
+                    sep=r"\s+",
                     header=None,
                     index_col=0,
                     )
@@ -521,7 +521,7 @@ def parse_output_for_tables(text, index="ZAM"):
                 string = io.StringIO("\n".join(lines[begin:]))
                 df = pd.read_csv(
                     string,
-                    sep="\s+",
+                    sep=r"\s+",
                     header=None,
                     index_col=index_col,
                     ).iloc[:, 1:]
@@ -542,7 +542,7 @@ def parse_table_nuclide(text, index="ZAM", data_row=3, **kwargs):
     string = io.StringIO(lines[0])
     columns = pd.read_csv(
         string,
-        sep="\s+",
+        sep=r"\s+",
         header=None,
         index_col=0,
         ).iloc[:, 1:].squeeze()
@@ -552,7 +552,7 @@ def parse_table_nuclide(text, index="ZAM", data_row=3, **kwargs):
         string = io.StringIO("\n".join(lines[begin:]))
         df = pd.read_csv(
             string,
-            sep="\s+",
+            sep=r"\s+",
             header=None,
             index_col=index_col,
             ).iloc[:, 1:]
@@ -568,7 +568,7 @@ def parse_table_energy(text, index="Energy", **kwargs):
     string = io.StringIO(lines[0])
     columns = pd.read_csv(
         string,
-        sep="\s+",
+        sep=r"\s+",
         header=None,
         index_col=0,
         ).iloc[:, 1:].squeeze()
@@ -578,7 +578,7 @@ def parse_table_energy(text, index="Energy", **kwargs):
         string = io.StringIO("\n".join(lines[begin:]))
         df = pd.read_csv(
             string,
-            sep="\s+",
+            sep=r"\s+",
             header=None,
             index_col=index_col,
             )
@@ -594,7 +594,7 @@ def parse_table_element(text, index="Element", **kwargs):
     string = io.StringIO(lines[0])
     columns = pd.read_csv(
         string,
-        sep="\s+",
+        sep=r"\s+",
         header=None,
         index_col=0,
         ).iloc[:, 1:].squeeze()
@@ -604,7 +604,7 @@ def parse_table_element(text, index="Element", **kwargs):
         string = io.StringIO("\n".join(lines[begin:]))
         df = pd.read_csv(
             string,
-            sep="\s+",
+            sep=r"\s+",
             header=None,
             index_col=index_col,
             ).iloc[:, 1:]
@@ -620,7 +620,7 @@ def parse_table_contributor(text, index="Main contributor", **kwargs):
     string = io.StringIO(lines[0])
     columns = pd.read_csv(
         string,
-        sep="\s+",
+        sep=r"\s+",
         header=None,
         index_col=(0, 1),  # "Time" and "(<unit>)" are in the first two columns
         ).iloc[0].reset_index(drop=True)
@@ -632,7 +632,7 @@ def parse_table_contributor(text, index="Main contributor", **kwargs):
         string = io.StringIO("\n".join(lines[begin:]))
         df = pd.read_csv(
             string,
-            sep="\s+",
+            sep=r"\s+",
             header=None,
             index_col=index_col,
             )
@@ -675,14 +675,14 @@ def parse_table(text, index="ZAM"):
     string = io.StringIO(lines[0])
     columns = pd.read_csv(
         string,
-        sep="\s+",
+        sep=r"\s+",
         header=None,
         index_col=0,
         ).iloc[:, 1:].squeeze()
     string = io.StringIO("\n".join(lines[begin:]))
     df = pd.read_csv(
         string,
-        sep="\s+",
+        sep=r"\s+",
         header=None,
         index_col=index_col,
         ).iloc[:, 1:]

--- a/sandy/aleph2/xs_output.py
+++ b/sandy/aleph2/xs_output.py
@@ -27,7 +27,7 @@ def read_xs_output(file):
         dataframe with cross sections.
     """
     df = pd.read_csv(file,
-                     sep='\s{2,}',
+                     sep=r'\s{2,}',
                      engine="python",
                      skiprows=1,
                      index_col=0,

--- a/sandy/aleph2/xsfile.py
+++ b/sandy/aleph2/xsfile.py
@@ -29,7 +29,7 @@ test_aleph2xs = """              952410                   4                   4 
   6.0000000000000000  5.0000000000000000
 """
 
-pattern_alephxsfile = "^.*_(?P<lib>.*)\\.(?P<tmp>.*)al"
+pattern_alephxsfile = r"^.*_(?P<lib>.*)\\.(?P<tmp>.*)al"
 
 
 def _lib_from_filename(file):

--- a/sandy/mcnp/mctal.py
+++ b/sandy/mcnp/mctal.py
@@ -229,7 +229,7 @@ def _from_block(text):
     if lines[ipos][0] != "f":  # skip fc comment
         ipos += 1
     # F bins
-    fdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep="\s+", engine='python').iloc[0]
+    fdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep=r"\s+", engine='python').iloc[0]
     nf = fdata[1]
     fbins = []
     while len(fbins) != nf:
@@ -237,12 +237,12 @@ def _from_block(text):
         fbins += list(map(int, lines[ipos].split()))
     ipos += 1
     # D bins
-    ddata = pd.read_csv(StringIO(lines[ipos]), header=None, sep="\s+", engine='python').iloc[0]
+    ddata = pd.read_csv(StringIO(lines[ipos]), header=None, sep=r"\s+", engine='python').iloc[0]
     nd = ddata[1]
     dbins = list(range(nd))
     ipos += 1
     # user bins
-    udata = pd.read_csv(StringIO(lines[ipos]), header=None, sep="\s+", engine='python').iloc[0]
+    udata = pd.read_csv(StringIO(lines[ipos]), header=None, sep=r"\s+", engine='python').iloc[0]
     nu = udata[1]
     if nu > 0:
         if udata[0].lower() == "ut":
@@ -255,7 +255,7 @@ def _from_block(text):
         ubins = list(range(1))
     ipos += 1
     # segment bin
-    sdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep="\s+", engine='python').iloc[0]
+    sdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep=r"\s+", engine='python').iloc[0]
     ns = sdata[1]
     if ns > 0:
         if sdata[0].lower() == "st":
@@ -268,7 +268,7 @@ def _from_block(text):
         sbins = list(range(1))
     ipos += 1
     # cosine bins
-    mdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep="\s+", engine='python').iloc[0]
+    mdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep=r"\s+", engine='python').iloc[0]
     nm = mdata[1]
     if nm > 0:
         if mdata[0].lower() == "mt":
@@ -281,7 +281,7 @@ def _from_block(text):
         mbins = list(range(1))
     ipos += 1
     # cosine bins
-    cdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep="\s+", engine='python').iloc[0]
+    cdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep=r"\s+", engine='python').iloc[0]
     nc = cdata[1]
     limit = int(np.ceil((nc-1)/6)) if cdata[0].lower() == "ct" or cdata[0].lower() == "cc" else int(np.ceil((nc)/6))
     cbins = []
@@ -297,7 +297,7 @@ def _from_block(text):
         cbins = list(range(1))
     ipos += 1
     # energy bins
-    edata = pd.read_csv(StringIO(lines[ipos]), header=None, sep="\s+", engine='python').iloc[0]
+    edata = pd.read_csv(StringIO(lines[ipos]), header=None, sep=r"\s+", engine='python').iloc[0]
     ne = edata[1]
     limit = int(np.ceil((ne-1)/6)) if edata[0].lower() == "et" or edata[0].lower() == "ec" else int(np.ceil((ne)/6))
     ebins = []
@@ -313,7 +313,7 @@ def _from_block(text):
         ebins = list(range(1))
     ipos += 1
     # time bins
-    tdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep="\s+", engine='python').iloc[0]
+    tdata = pd.read_csv(StringIO(lines[ipos]), header=None, sep=r"\s+", engine='python').iloc[0]
     nt = tdata[1]
     limit = int(np.ceil((nt-1)/6)) if tdata[0].lower() == "tt" or tdata[0].lower() == "tc" else int(np.ceil((nt)/6))
     tbins = []

--- a/sandy/mcnp/meshtal.py
+++ b/sandy/mcnp/meshtal.py
@@ -216,11 +216,11 @@ class MshtTally():
             sections = block.split("\n\n")
             idx = int(sections[0].splitlines()[0])
             data = re.sub(
-                    "Rslt \* Vol",
+                    r"Rslt \* Vol",
                     "RsltVol",
                     re.sub("Rel Error", "RelError", sections[2]),
                     )
-            df = pd.read_csv(io.StringIO(data), sep="\s+")
+            df = pd.read_csv(io.StringIO(data), sep=r"\s+")
             out[idx] = cls(df)
         return out
 

--- a/sandy/mcnp/output_file.py
+++ b/sandy/mcnp/output_file.py
@@ -16,7 +16,7 @@ __all__ = [
 def get_keff(file):
     with open(file, 'r') as f:
         text = f.read()
-    PATTERN = "final estimate.*= (?P<keff>[\.0-9]+).*?(?P<stdev>[\.0-9]+)"
+    PATTERN = r"final estimate.*= (?P<keff>[\.0-9]+).*?(?P<stdev>[\.0-9]+)"
     match = re.search(PATTERN, text)
     keff = float(match.group("keff"))
     std = float(match.group("stdev"))
@@ -28,7 +28,7 @@ def get_table126(file):
     with open(file, 'r') as f:
         text = f.read()
 
-    PATTERN = "(?:^1neutron.*table 126\n)(?P<table>(?:.*\n)+?)(?P<end>^\s{11}total\s{2})"
+    PATTERN = r"(?:^1neutron.*table 126\n)(?P<table>(?:.*\n)+?)(?P<end>^\s{11}total\s{2})"
     match = re.search(PATTERN, text, re.MULTILINE).group("table")
     widths=[9, 10, 12, 14, 13, 14, 13, 13, 13, 13]
     dtypes = [int] * 5 + [float] * 5
@@ -57,7 +57,7 @@ def get_table140(file):
     with open(file, 'r') as f:
         text = f.read()
 
-    PATTERN = "(?:^1neutron.*table 140\n)(?P<table>(?:.*\n)+?)(?P<end>^\s+total\s{20})"
+    PATTERN = r"(?:^1neutron.*table 140\n)(?P<table>(?:.*\n)+?)(?P<end>^\s+total\s{20})"
     match = re.search(PATTERN, text, re.MULTILINE).group("table")
     widths=[10, 9, 11, 9,] + [12] * 6
     dtypes = [int, int, str, float, int, float, float, float, float, int]

--- a/sandy/pert.py
+++ b/sandy/pert.py
@@ -236,7 +236,7 @@ class Pert():
         ----------
         file : `str`
             file name (absolute or relative path)
-        sep : `str`, optional, default `"\s+"`
+        sep : `str`, optional, default `r"\\s+"`
             column separator. By default it takes blankspaces as separators.
             .. note:: for `csv` files use `","`
         **kwargs : `pandas.read_csv` properties, optional

--- a/sandy/shared.py
+++ b/sandy/shared.py
@@ -332,8 +332,8 @@ def add_delimiter_every_n_characters(string, step, delimiter=" "):
 
 
 def add_exp_in_endf6_text(text):
-    pattern = re.compile("([0-9\.])([+-])([0-9])")
-    return pattern.sub("\g<1>E\g<2>\g<3>", text)
+    pattern = re.compile(r"([0-9\.])([+-])([0-9])")
+    return pattern.sub(r"\g<1>E\g<2>\g<3>", text)
 
 
 def star(func):


### PR DESCRIPTION
Updated Python expressions to use raw string literals (r"") for regular expressions, thus resolving warnings which were flagged during coverage tests.