### PR TITLE
Allow empty MODn value as zeros in MF1 MT451

### DIFF
--- a/sandy/sections/mf1.py
+++ b/sandy/sections/mf1.py
@@ -480,6 +480,7 @@ def _read_intro(tape, mat):
     sections = []
     for j in range(NXC):
         T, i = sandy.read_text(df, i)
+        # if MOD is left empty, add a 0 
         s = tuple(map(lambda x: 0 if x.strip() == "" else int(x), 
                       re.findall(".{11}", T[0])[2:])
                   )

--- a/sandy/sections/mf1.py
+++ b/sandy/sections/mf1.py
@@ -480,7 +480,9 @@ def _read_intro(tape, mat):
     sections = []
     for j in range(NXC):
         T, i = sandy.read_text(df, i)
-        s = tuple(map(int, re.findall(".{11}" , T[0])[2:]))
+        s = tuple(map(lambda x: 0 if x.strip() == "" else int(x), 
+                      re.findall(".{11}", T[0])[2:])
+                  )
         sections.append(s)
     out.update({
         "SECTIONS": sections,


### PR DESCRIPTION
This is a simple fix for this #401 issue. Not sure how to create a test for this as the bug is seen on JEFF-4 which are not yet available with get_endf6_file()